### PR TITLE
docs: polish content

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ MCP Auth gives you everything you need to add production-ready auth to your MCP 
 
 ## Highlights
 
-### Skip the specs. Skip the boilerplate. Just auth.
+### 1. Skip the specs. Skip the boilerplate. Just auth.
 
 The MCP spec [requires OAuth 2.1 and other RFCs](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization) for auth. Instead of spending weeks on them, use MCP Auth to connect to an trusted provider with a few lines of code.
 
-### Connect to any provider. It's provider-agnostic.
+### 2. Connect to any provider. It's provider-agnostic.
 
 MCP Auth works with any compliant OAuth 2.1 or OpenID Connect provider. Choose one from our verified list or use the tool to check if your provider is compliant.
 

--- a/docs/configure-server/mcp-auth.mdx
+++ b/docs/configure-server/mcp-auth.mdx
@@ -99,7 +99,7 @@ mcp_auth = MCPAuth(
     server=fetch_server_config_by_well_known_url(
         '<metadata-url>',
         type=AuthServerType.OIDC,
-        transpile_data=lambda data: {**data, 'response_types_supported': ['code']}
+        transpile_data=lambda data: {**data, 'response_types_supported': ['code']} # [!code highlight]
     )
 )
 ```
@@ -111,7 +111,7 @@ mcp_auth = MCPAuth(
 const mcpAuth = new MCPAuth({
   server: await fetchServerConfigByWellKnownUrl('<metadata-url>', {
     type: 'oidc',
-    transpileData: (data) => ({ ...data, response_types_supported: ['code'] }),
+    transpileData: (data) => ({ ...data, response_types_supported: ['code'] }), // [!code highlight]
   }),
 });
 ```

--- a/docs/tutorials/_whoami-setup-oauth.mdx
+++ b/docs/tutorials/_whoami-setup-oauth.mdx
@@ -7,7 +7,7 @@ import ManualMetadataFetching from './_whoami-manual-metadata-fetching.mdx';
 
 <TabItem value="python" label="Python">
 
-Update the MCP server file to include the MCP Auth configuration:
+Update the `whoami.py` to include the MCP Auth configuration:
 
 ```python
 from mcpauth import MCPAuth
@@ -77,7 +77,7 @@ def verify_access_token(token: str) -> AuthInfo:
 </TabItem>
 <TabItem value="node" label="Node.js">
 
-Update the MCP server file to include the MCP Auth configuration:
+Update the `whoami.js` to include the MCP Auth configuration:
 
 ```js
 import { MCPAuth, fetchServerConfig } from 'mcp-auth';
@@ -111,7 +111,7 @@ const verifyToken = async (token) => {
     throw new MCPAuthTokenVerificationError('token_verification_failed', response);
   }
 
-  const userInfo: unknown = await response.json();
+  const userInfo = await response.json();
 
   // The following code assumes the user info response is an object with a 'sub' field that
   // identifies the user. You may need to adjust this based on your provider's API.

--- a/docs/tutorials/_whoami-setup-oauth.mdx
+++ b/docs/tutorials/_whoami-setup-oauth.mdx
@@ -2,6 +2,7 @@ import TabItem from '@theme/TabItem';
 import Tabs from '@theme/Tabs';
 
 import ManualMetadataFetching from './_whoami-manual-metadata-fetching.mdx';
+import MalformedMetadataTranspilation from './_whoami-transpile-metadata.mdx';
 
 <Tabs groupId="sdk">
 
@@ -19,9 +20,30 @@ auth_server_config = fetch_server_config(auth_issuer, type=AuthServerType.OAUTH)
 mcp_auth = MCPAuth(server=auth_server_config)
 ```
 
+</TabItem>
+<TabItem value="node" label="Node.js">
+
+Update the `whoami.js` to include the MCP Auth configuration:
+
+```js
+import { MCPAuth, fetchServerConfig } from 'mcp-auth';
+
+const authIssuer = '<issuer-endpoint>'; // Replace with your issuer endpoint
+const mcpAuth = new MCPAuth({
+  server: await fetchServerConfig(authIssuer, { type: 'oauth' }),
+});
+```
+
+</TabItem>
+</Tabs>
+
+<MalformedMetadataTranspilation />
 <ManualMetadataFetching />
 
 Now, we need to create a custom access token verifier that will fetch the user identity information from the authorization server using the access token provided by the MCP inspector.
+
+<Tabs groupId="sdk">
+<TabItem value="python" label="Python">
 
 ```python
 import pydantic
@@ -76,21 +98,6 @@ def verify_access_token(token: str) -> AuthInfo:
 
 </TabItem>
 <TabItem value="node" label="Node.js">
-
-Update the `whoami.js` to include the MCP Auth configuration:
-
-```js
-import { MCPAuth, fetchServerConfig } from 'mcp-auth';
-
-const authIssuer = '<issuer-endpoint>'; // Replace with your issuer endpoint
-const mcpAuth = new MCPAuth({
-  server: await fetchServerConfig(authIssuer, { type: 'oauth' }),
-});
-```
-
-<ManualMetadataFetching />
-
-Now, we need to create a custom access token verifier that will fetch the user identity information from the authorization server using the access token provided by the MCP inspector.
 
 ```js
 import { MCPAuthTokenVerificationError } from 'mcp-auth';

--- a/docs/tutorials/_whoami-setup-oidc.mdx
+++ b/docs/tutorials/_whoami-setup-oidc.mdx
@@ -7,7 +7,7 @@ import ManualMetadataFetching from './_whoami-manual-metadata-fetching.mdx';
 
 <TabItem value="python" label="Python">
 
-Update the MCP server file to include the MCP Auth configuration:
+Update the `whoami.py` to include the MCP Auth configuration:
 
 ```python
 from mcpauth import MCPAuth
@@ -77,7 +77,7 @@ def verify_access_token(token: str) -> AuthInfo:
 </TabItem>
 <TabItem value="node" label="Node.js">
 
-Update the MCP server file to include the MCP Auth configuration:
+Update the `whoami.js` to include the MCP Auth configuration:
 
 ```js
 import { MCPAuth, fetchServerConfig } from 'mcp-auth';
@@ -114,7 +114,7 @@ const verifyToken = async (token) => {
     throw new MCPAuthTokenVerificationError('token_verification_failed', response);
   }
 
-  const userInfo: unknown = await response.json();
+  const userInfo = await response.json();
 
   if (typeof userInfo !== 'object' || userInfo === null || !('sub' in userInfo)) {
     throw new MCPAuthTokenVerificationError('invalid_token', response);

--- a/docs/tutorials/_whoami-setup-oidc.mdx
+++ b/docs/tutorials/_whoami-setup-oidc.mdx
@@ -62,6 +62,7 @@ def verify_access_token(token: str) -> AuthInfo:
     :param token: The Bearer token to received from the MCP inspector.
     """
 
+    issuer = auth_server_config.metadata.issuer
     endpoint = auth_server_config.metadata.userinfo_endpoint # The provider should support the userinfo endpoint
     if not endpoint:
         raise ValueError(
@@ -78,7 +79,7 @@ def verify_access_token(token: str) -> AuthInfo:
         return AuthInfo(
             token=token,
             subject=json.get("sub"), # 'sub' is a standard claim for the subject (user's ID)
-            issuer=auth_issuer, # Use the configured issuer
+            issuer=issuer, # Use the issuer from the metadata
             claims=json, # Include all claims (JSON fields) returned by the userinfo endpoint
         )
     # `AuthInfo` is a Pydantic model, so validation errors usually mean the response didn't match
@@ -107,7 +108,7 @@ import { MCPAuthTokenVerificationError } from 'mcp-auth';
  * If the token is valid, it returns an `AuthInfo` object containing the user's information.
  */
 const verifyToken = async (token) => {
-  const { userinfoEndpoint } = mcpAuth.config.server.metadata;
+  const { issuer, userinfoEndpoint } = mcpAuth.config.server.metadata;
 
   if (!userinfoEndpoint) {
     throw new Error('Userinfo endpoint is not configured in the server metadata');
@@ -129,7 +130,7 @@ const verifyToken = async (token) => {
 
   return {
     token,
-    issuer: authIssuer,
+    issuer,
     subject: String(userInfo.sub), // 'sub' is a standard claim for the subject (user's ID)
     clientId: '', // Client ID is not used in this example, but can be set if needed
     scopes: [],

--- a/docs/tutorials/_whoami-setup-oidc.mdx
+++ b/docs/tutorials/_whoami-setup-oidc.mdx
@@ -2,6 +2,7 @@ import TabItem from '@theme/TabItem';
 import Tabs from '@theme/Tabs';
 
 import ManualMetadataFetching from './_whoami-manual-metadata-fetching.mdx';
+import MalformedMetadataTranspilation from './_whoami-transpile-metadata.mdx';
 
 <Tabs groupId="sdk">
 
@@ -19,9 +20,30 @@ auth_server_config = fetch_server_config(auth_issuer, type=AuthServerType.OIDC)
 mcp_auth = MCPAuth(server=auth_server_config)
 ```
 
+</TabItem>
+<TabItem value="node" label="Node.js">
+
+Update the `whoami.js` to include the MCP Auth configuration:
+
+```js
+import { MCPAuth, fetchServerConfig } from 'mcp-auth';
+
+const authIssuer = '<issuer-endpoint>'; // Replace with your issuer endpoint
+const mcpAuth = new MCPAuth({
+  server: await fetchServerConfig(authIssuer, { type: 'oidc' }),
+});
+```
+
+</TabItem>
+</Tabs>
+
+{props.showAlternative && <MalformedMetadataTranspilation />}
 {props.showAlternative && <ManualMetadataFetching oidc />}
 
 Now, we need to create a custom access token verifier that will fetch the user identity information from the authorization server using the access token provided by the MCP inspector.
+
+<Tabs groupId="sdk">
+<TabItem value="python" label="Python">
 
 ```python
 import pydantic
@@ -76,21 +98,6 @@ def verify_access_token(token: str) -> AuthInfo:
 
 </TabItem>
 <TabItem value="node" label="Node.js">
-
-Update the `whoami.js` to include the MCP Auth configuration:
-
-```js
-import { MCPAuth, fetchServerConfig } from 'mcp-auth';
-
-const authIssuer = '<issuer-endpoint>'; // Replace with your issuer endpoint
-const mcpAuth = new MCPAuth({
-  server: await fetchServerConfig(authIssuer, { type: 'oidc' }),
-});
-```
-
-{props.showAlternative && <ManualMetadataFetching oidc />}
-
-Now, we need to create a custom access token verifier that will fetch the user identity information from the authorization server using the access token provided by the MCP inspector.
 
 ```js
 import { MCPAuthTokenVerificationError } from 'mcp-auth';

--- a/docs/tutorials/_whoami-transpile-metadata.mdx
+++ b/docs/tutorials/_whoami-transpile-metadata.mdx
@@ -1,0 +1,31 @@
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
+In some cases, the provider response may be malformed or not conforming to the expected metadata format. If you are confident that the provider is compliant, you can transpile the metadata via the config option:
+
+<Tabs groupId="sdk">
+<TabItem value="python" label="Python">
+
+```python
+mcp_auth = MCPAuth(
+    server=fetch_server_config(
+        # ...other options
+        transpile_data=lambda data: {**data, 'response_types_supported': ['code']} # [!code highlight]
+    )
+)
+```
+
+</TabItem>
+<TabItem value="node" label="Node.js">
+
+```ts
+const mcpAuth = new MCPAuth({
+  server: await fetchServerConfig(authIssuer, {
+    // ...other options
+    transpileData: (data) => ({ ...data, response_types_supported: ['code'] }), // [!code highlight]
+  }),
+});
+```
+
+</TabItem>
+</Tabs>

--- a/docs/tutorials/whoami.mdx
+++ b/docs/tutorials/whoami.mdx
@@ -85,13 +85,41 @@ Dynamic Client Registration is not required for this tutorial, but it can be use
 
 We will use the [MCP official SDKs](https://github.com/modelcontextprotocol) to create a MCP server with a `whoami` tool that retrieves user identity information from the authorization server.
 
-### Install the MCP SDK
+### Create a new project
 
 <Tabs groupId="sdk">
 <TabItem value="python" label="Python">
 
 ```bash
-pip install "mcp[cli]"
+mkdir mcp-server
+cd mcp-server
+uv init # Or use `pipenv` or `poetry` to create a new virtual environment
+```
+
+</TabItem>
+<TabItem value="node" label="Node.js">
+
+Set up a new Node.js project:
+
+```bash
+mkdir mcp-server
+cd mcp-server
+npm init -y # Or use `pnpm init`
+npm pkg set type="module"
+npm pkg set main="whoami.js"
+npm pkg set scripts.start="node whoami.js"
+```
+
+</TabItem>
+</Tabs>
+
+### Install the MCP SDK and dependencies
+
+<Tabs groupId="sdk">
+<TabItem value="python" label="Python">
+
+```bash
+pip install "mcp[cli]" starlette uvicorn
 ```
 
 Or any other package manager you prefer, such as `uv` or `poetry`.
@@ -100,7 +128,7 @@ Or any other package manager you prefer, such as `uv` or `poetry`.
 <TabItem value="node" label="Node.js">
 
 ```bash
-npm install @modelcontextprotocol/sdk
+npm install @modelcontextprotocol/sdk express
 ```
 
 Or any other package manager you prefer, such as `pnpm` or `yarn`.
@@ -146,6 +174,8 @@ uvicorn whoami:app --host 0.0.0.0 --port 3001
 :::note
 Since the current MCP inspector implementation does not handle authorization flows, we will use the SSE approach to set up the MCP server. We'll update the code here once the MCP inspector supports authorization flows.
 :::
+
+You can also use `pnpm` or `yarn` if you prefer.
 
 Create a file named `whoami.js` and add the following code:
 
@@ -200,7 +230,7 @@ app.listen(PORT);
 Run the server with:
 
 ```bash
-node whoami.js
+npm start
 ```
 
 </TabItem>
@@ -475,7 +505,7 @@ Check out the [MCP Auth Python SDK repository](https://github.com/mcp-auth/pytho
 <TabItem value="node" label="Node.js">
 
 :::info
-Check out the [MCP Auth Node.js SDK repository](https://github.com/mcp-auth/js/blob/master/packages/sample-servers/src/whoami.ts) for the complete code of the MCP server (OIDC version).
+Check out the [MCP Auth Node.js SDK repository](https://github.com/mcp-auth/js/blob/master/packages/sample-servers/src) for the complete code of the MCP server (OIDC version). This directory contains both TypeScript and JavaScript versions of the code.
 :::
 
 </TabItem>


### PR DESCRIPTION
- make content clearer
- make readme titles consistent
- reorg metadata config content to handle malformed metadata responses
- update issuer usage in the tutorial to match the server metadata