### PR TITLE
refactor: reorg mcp auth init methods

### DIFF
--- a/docs/configure-server/mcp-auth.mdx
+++ b/docs/configure-server/mcp-auth.mdx
@@ -12,6 +12,8 @@ To connect your MCP server to an OAuth 2.1 or OpenID Connect provider, you need 
 
 ## Init MCP Auth
 
+### Automatic metadata fetching
+
 The easiest way to initialize the MCP Auth instance is by using the built-in functions that fetch the metadata from a well-known URL. If your provider conforms to one of the following standards:
 
 - [OAuth 2.0 Authorization Server Metadata](https://datatracker.ietf.org/doc/html/rfc8414)
@@ -49,10 +51,49 @@ const mcpAuth = new MCPAuth({
 
 If your issuer includes a path, the behavior differs slightly between OAuth 2.0 and OpenID Connect:
 
-- **OAuth 2.0**: The well-known URL is appended to the **domain** of the issuer. For example, if your issuer is `https://auth.logto.io/oauth`, the well-known URL will be `https://auth.logto.io/.well-known/oauth-authorization-server/oauth`.
-- **OpenID Connect**: The well-known URL is appended directly to the **issuer**. For example, if your issuer is `https://auth.logto.io/oidc`, the well-known URL will be `https://auth.logto.io/oidc/.well-known/openid-configuration`.
+- **OAuth 2.0**: The well-known URL is appended to the **domain** of the issuer. For example, if your issuer is `https://my-project.logto.app/oauth`, the well-known URL will be `https://auth.logto.io/.well-known/oauth-authorization-server/oauth`.
+- **OpenID Connect**: The well-known URL is appended directly to the **issuer**. For example, if your issuer is `https://my-project.logto.app/oidc`, the well-known URL will be `https://auth.logto.io/oidc/.well-known/openid-configuration`.
 
 ### Other ways to initialize MCP Auth {#other-ways}
+
+#### Custom data transpilation
+
+In some cases, the metadata returned by the provider may not conform to the expected format. If you are confident that the provider is compliant, you can use the `transpile_data` option to modify the metadata before it is used:
+
+<Tabs groupId="sdk">
+<TabItem value="python" label="Python">
+
+```python
+from mcpauth import MCPAuth
+from mcpauth.config import AuthServerType
+from mcpauth.utils import fetch_server_config
+
+mcp_auth = MCPAuth(
+    server=fetch_server_config(
+        '<auth-server-url>',
+        type=AuthServerType.OIDC,
+        transpile_data=lambda data: {**data, 'response_types_supported': ['code']} # [!code highlight]
+    )
+)
+```
+</TabItem>
+<TabItem value="node" label="Node.js">
+
+```ts
+import { MCPAuth, fetchServerConfig } from 'mcp-auth';
+const mcpAuth = new MCPAuth({
+  server: await fetchServerConfig('<auth-server-issuer>', {
+    type: 'oidc',
+    transpileData: (data) => ({ ...data, response_types_supported: ['code'] }), // [!code highlight]
+  }),
+});
+```
+</TabItem>
+</Tabs>
+
+This allows you to modify the metadata object before it is used by MCP Auth. For example, you can add or remove fields, change their values, or convert them to a different format.
+
+#### Fetch metadata from a specific URL
 
 If your provider has a specific metadata URL rather than the standard ones, you can use it similarly:
 
@@ -86,6 +127,8 @@ const mcpAuth = new MCPAuth({
 </TabItem>
 </Tabs>
 
+#### Fetch metadata from a specific URL with custom data transpilation
+
 In some cases, the provider response may be malformed or not conforming to the expected metadata format. If you are confident that the provider is compliant, you can transpile the metadata via the config option:
 
 <Tabs groupId="sdk">
@@ -118,6 +161,8 @@ const mcpAuth = new MCPAuth({
 
 </TabItem>
 </Tabs>
+
+#### Manually provide metadata
 
 If your provider does not support metadata fetching, you can manually provide the metadata object:
 

--- a/src/components/TestProvider/index.module.css
+++ b/src/components/TestProvider/index.module.css
@@ -21,6 +21,15 @@
   color: var(--ifm-color-success-light);
 }
 
+.statusFixable {
+  color: var(--ifm-color-warning-light);
+}
+
+.statusFixable a {
+  color: var(--ifm-color-warning-light);
+  text-decoration: underline;
+}
+
 .statusInvalid {
   color: var(--ifm-color-danger-light);
 }


### PR DESCRIPTION
- reorg mcp auth init methods
- show fixable info if the only error is `authorization_code_grant_not_supported` in provider tester