### PR TITLE
Add Asgardeo and WSO2 Identity Server to the supported provider list

### DIFF
--- a/docs/provider-list.mdx
+++ b/docs/provider-list.mdx
@@ -14,7 +14,7 @@ This list contains providers that have been tested with MCP Auth.
 | [Logto](https://logto.io)                                  | OpenID Connect | ✅        | ✅           | ❌[^1]                       | ✅                 |
 | [Keycloak](https://www.keycloak.org)                       | OpenID Connect | ✅        | ✅           | ⚠️[^2]                       | ❌                 |
 | [Asgardeo](https://wso2.com/asgardeo)                      | OpenID Connect | ✅        | ✅           | ✅                           | ❌                 |
-| [WSO2 Identity Server](https://github.com/wso2/product-is) | OpenID Connect | ✅        | ✅           | ✅                           | ❌                 |
+| [WSO2 Identity Server](https://wso2.com/identity-server/) | OpenID Connect | ✅        | ✅           | ✅                           | ❌                 |
 
 If you have tested MCP Auth with another provider, please feel free to submit a pull request to add it to the list.
 

--- a/docs/provider-list.mdx
+++ b/docs/provider-list.mdx
@@ -9,10 +9,12 @@ import TestProvider from '@site/src/components/TestProvider';
 
 This list contains providers that have been tested with MCP Auth.
 
-| Provider                             | Type           | OAuth 2.1 | Metadata URL | Dynamic Client Registration | Resource Indicator |
-| ------------------------------------ | -------------- | --------- | ------------ | --------------------------- | ------------------ |
-| [Logto](https://logto.io)            | OpenID Connect | ✅        | ✅           | ❌[^1]                      | ✅                 |
-| [Keycloak](https://www.keycloak.org) | OpenID Connect | ✅        | ✅           | ⚠️[^2]                      | ❌                 |
+| Provider                                                   | Type           | OAuth 2.1 | Metadata URL | Dynamic Client Registration | Resource Indicator |
+| ---------------------------------------------------------- | -------------- | --------- | ------------ | --------------------------- | ------------------ |
+| [Logto](https://logto.io)                                  | OpenID Connect | ✅        | ✅           | ❌[^1]                       | ✅                 |
+| [Keycloak](https://www.keycloak.org)                       | OpenID Connect | ✅        | ✅           | ⚠️[^2]                       | ❌                 |
+| [Asgardeo](https://wso2.com/asgardeo)                      | OpenID Connect | ✅        | ✅           | ✅                           | ❌                 |
+| [WSO2 Identity Server](https://github.com/wso2/product-is) | OpenID Connect | ✅        | ✅           | ✅                           | ❌                 |
 
 If you have tested MCP Auth with another provider, please feel free to submit a pull request to add it to the list.
 


### PR DESCRIPTION
This PR adds Asgardeo and WSO2 Identity Server to the list of supported identity providers. 