### PR TITLE
Add Auth0 to provider list

### DIFF
--- a/docs/provider-list.mdx
+++ b/docs/provider-list.mdx
@@ -9,10 +9,11 @@ import TestProvider from '@site/src/components/TestProvider';
 
 This list contains providers that have been tested with MCP Auth.
 
-| Provider                                                   | Type           | OAuth 2.1 | Metadata URL | Dynamic Client Registration | Resource Indicator |
-| ---------------------------------------------------------- | -------------- | --------- | ------------ | --------------------------- | ------------------ |
-| [Logto](https://logto.io)                                  | OpenID Connect | ✅        | ✅           | ❌[^1]                       | ✅                 |
-| [Keycloak](https://www.keycloak.org)                       | OpenID Connect | ✅        | ✅           | ⚠️[^2]                       | ❌                 |
+| Provider                             | Type           | OAuth 2.1 | Metadata URL | Dynamic Client Registration | Resource Indicator |
+| ------------------------------------ | -------------- | --------- | ------------ | --------------------------- | ------------------ |
+| [Logto](https://logto.io)            | OpenID Connect | ✅        | ✅           | ❌[^1]                      | ✅                 |
+| [Keycloak](https://www.keycloak.org) | OpenID Connect | ✅        | ✅           | ⚠️[^2]                      | ❌                 |
+| [Auth0](https://www.auth0.com)       | OpenID Connect | ✅        | ✅           | ✅                          | ⚠️[^3]             |
 | [Asgardeo](https://wso2.com/asgardeo)                      | OpenID Connect | ✅        | ✅           | ✅                           | ❌                 |
 | [WSO2 Identity Server](https://wso2.com/identity-server/) | OpenID Connect | ✅        | ✅           | ✅                           | ❌                 |
 
@@ -21,6 +22,8 @@ If you have tested MCP Auth with another provider, please feel free to submit a 
 [^1]: Logto is working on adding support for dynamic client registration.
 
 [^2]: While Keycloak supports dynamic client registration, its client registration endpoint does not support CORS, preventing most MCP clients from registering directly.
+
+[^3]: Auth0 supports multi-resource refresh tokens (MRRT) but not full RFC 8707. Resource indicator support is limited and not standards-based.
 
 ## Is Dynamic Client Registration required? {#is-dcr-required}
 

--- a/docs/provider-list.mdx
+++ b/docs/provider-list.mdx
@@ -9,21 +9,23 @@ import TestProvider from '@site/src/components/TestProvider';
 
 This list contains providers that have been tested with MCP Auth.
 
-| Provider                             | Type           | OAuth 2.1 | Metadata URL | Dynamic Client Registration | Resource Indicator |
-| ------------------------------------ | -------------- | --------- | ------------ | --------------------------- | ------------------ |
-| [Logto](https://logto.io)            | OpenID Connect | ✅        | ✅           | ❌[^1]                      | ✅                 |
-| [Keycloak](https://www.keycloak.org) | OpenID Connect | ✅        | ✅           | ⚠️[^2]                      | ❌                 |
-| [Auth0](https://www.auth0.com)       | OpenID Connect | ✅        | ✅           | ✅                          | ⚠️[^3]             |
-| [Asgardeo](https://wso2.com/asgardeo)                      | OpenID Connect | ✅        | ✅           | ✅                           | ❌                 |
-| [WSO2 Identity Server](https://wso2.com/identity-server/) | OpenID Connect | ✅        | ✅           | ✅                           | ❌                 |
+| Provider                                                  | Type           | OAuth 2.1 | Metadata URL | Dynamic Client Registration | Resource Indicator[^1] |
+| --------------------------------------------------------- | -------------- | --------- | ------------ | --------------------------- | ---------------------- |
+| [Logto](https://logto.io)                                 | OpenID Connect | ✅        | ✅           | ❌[^2]                      | ✅                     |
+| [Keycloak](https://www.keycloak.org)                      | OpenID Connect | ✅        | ✅           | ⚠️[^3]                      | ❌                     |
+| [Auth0](https://www.auth0.com)                            | OpenID Connect | ✅        | ✅           | ✅                          | ⚠️[^4]                 |
+| [Asgardeo](https://wso2.com/asgardeo)                     | OpenID Connect | ✅        | ✅           | ✅                          | ❌                     |
+| [WSO2 Identity Server](https://wso2.com/identity-server/) | OpenID Connect | ✅        | ✅           | ✅                          | ❌                     |
 
 If you have tested MCP Auth with another provider, please feel free to submit a pull request to add it to the list.
 
-[^1]: Logto is working on adding support for dynamic client registration.
+[^1]: Resource Indicator stands for [RFC 8707: Resource Indicators for OAuth 2.0](https://datatracker.ietf.org/doc/html/rfc8707), which is a standard for indicating the resource a client wants to access.
 
-[^2]: While Keycloak supports dynamic client registration, its client registration endpoint does not support CORS, preventing most MCP clients from registering directly.
+[^2]: Logto is working on adding support for dynamic client registration.
 
-[^3]: Auth0 supports multi-resource refresh tokens (MRRT) but not full RFC 8707. Resource indicator support is limited and not standards-based.
+[^3]: While Keycloak supports dynamic client registration, its client registration endpoint does not support CORS, preventing most MCP clients from registering directly.
+
+[^4]: Auth0 supports multi-resource refresh tokens (MRRT) but not full RFC 8707. Resource indicator support is limited and not standards-based.
 
 ## Is Dynamic Client Registration required? {#is-dcr-required}
 


### PR DESCRIPTION
## Summary
After addressing the [open issues](https://github.com/orgs/mcp-auth/discussions/33), this PR adds Auth0 to the documented list of identity providers tested [with MCP Auth](https://mcp-auth.dev/docs/provider-list).

What’s included:
- Updates to the Provider list page to include Auth0, with ✅ for dynamic client registration and ⚠️ for resource indicator support.
- Footnote explains that while Auth0 supports [multi-resource refresh tokens (MRRT)](https://learn.microsoft.com/en-us/entra/identity-platform/multi-resource-refresh-tokens), it does not support full RFC 8707 resource indicators.
- Verified that Auth0 passes all compatibility checks via the embedded `<TestProvider />` tool.
- Minor clarification added to the dynamic client registration FAQ to guide users based on their use case (internal vs. public MCP servers).

This helps users better evaluate which providers are plug-and-play with MCP Auth and what workarounds or limitations to expect.

Open to feedback or additional notes on edge-case behavior.

## Test plan
Verified provider is displayed correctly in the documentation:
<img width="788" alt="image" src="https://github.com/user-attachments/assets/6c924e44-7226-4eea-99dd-24e0a99bcd28" />

And with the test tool:
![image](https://github.com/user-attachments/assets/e5c43eaa-39cf-47cf-acaf-51705db98d8d)
