### PR TITLE
docs: add LIME to MCP-compatible provider list

### DIFF
--- a/src/pages/provider-list.mdx
+++ b/src/pages/provider-list.mdx
@@ -16,6 +16,7 @@ This list contains providers that have been tested with MCP Auth.
 | [WSO2 Identity Server](https://wso2.com/identity-server/) | OpenID Connect | ✅        | ✅           | ✅                          | ❌                     |
 | [Auth0](https://www.auth0.com)                            | OpenID Connect | ✅        | ✅           | ✅                          | ⚠️[^4]                 |
 | [Descope](https://www.descope.com)                        | OpenID Connect | ✅        | ✅           | ✅                          | ⚠️[^4]                 |
+| [LIME](https://lime.pics)                                 | OAuth 2.1      | ✅        | ✅           | ⚠️[^5]                      | ❌                     |
 
 If you have tested MCP Auth with another provider, please feel free to submit a pull request to add it to the list.
 
@@ -26,6 +27,8 @@ If you have tested MCP Auth with another provider, please feel free to submit a 
 [^3]: While Keycloak supports dynamic client registration, its client registration endpoint does not support CORS, preventing most MCP clients from registering directly.
 
 [^4]: Auth0 and Descope support multi-resource refresh tokens (MRRT) but not full RFC 8707. Resource indicator support is limited and not standards-based.
+
+[^5]: `registration_endpoint` is advertised in metadata; `POST /register` returns 501. Agent authentication uses the `X-Agent-Token` header at `/authorize` (LIME-specific).
 
 ## Is Dynamic Client Registration required? {#is-dcr-required}
 


### PR DESCRIPTION
## Summary
Adds [LIME](https://lime.pics) to the MCP-compatible provider list.

## Test results
Tested on https://mcp-auth.dev/provider-list with issuer `https://lime.pics`:
- **Result:** Compatible with MCP
- **6 successes**, 0 warnings

Discovery endpoints:
- `https://lime.pics/.well-known/oauth-authorization-server`
- `https://lime.pics/api/v1/modules/oauth/.well-known/oauth-authorization-server`

## Notes
- OAuth 2.1 Authorization Server (RFC 8414), not full OpenID Connect
- DCR: `registration_endpoint` is advertised in metadata; `POST /register` returns 501 (marked ⚠️ in table)
- No RFC 8707 resource indicators
- `/authorize` requires `X-Agent-Token` (LIME-specific extension)